### PR TITLE
State no longer is held in global, rc4plus_init func and offset option for enc-dec func were implemented

### DIFF
--- a/src/rc4plus.c
+++ b/src/rc4plus.c
@@ -1,26 +1,34 @@
 #include "rc4plus.h"
 
-unsigned char RC4PLUS_STATE[256];
-unsigned char RC4PLUS_IV[RC4PLUS_IV_SIZE];
-
-unsigned char get_iv_char(unsigned char index)
+unsigned char get_iv_char(const char *const iv, unsigned char index)
 {
     if ( index < (128 - RC4PLUS_IV_SIZE) ) {
         return 0;
     } else if ( index < 128 ) {
-        return RC4PLUS_IV[128 - 1 - index];
+        return iv[128 - 1 - index];
     } else if ( index < 128 + RC4PLUS_IV_SIZE ) {
-        return RC4PLUS_IV[index - 128];
+        return iv[index - 128];
     } else {
         return 0;
     }
 }
 
-int rc4plus_set_key(const char *const key, const char *const iv)
+int rc4plus_destroy(rc4struct *rcstruct)
+{
+    if ( rcstruct == NULL ) {
+        //NULL ptr error
+        return -1;
+    }
+    memset(rcstruct->state, 0, sizeof(rcstruct->state));
+    free(rcstruct);
+    return 0;
+}
+
+rc4struct *rc4plus_init(const char *const key, const char *const iv)
 {
     if ( key == NULL || iv == NULL ) {
         //NULL ptr error
-        return -1;
+        return NULL;
     }
 
     size_t key_length = strnlen(key, 256);
@@ -29,44 +37,50 @@ int rc4plus_set_key(const char *const key, const char *const iv)
         printf("Warning, long key! First 256 byte of the key will be taken.\n");
     } else if (  !key_length ) {
         //Key length error
-        return -1;
+        return NULL;
     }
 
     //IV length check
     if ( strnlen(iv, RC4PLUS_IV_SIZE) < RC4PLUS_IV_SIZE ) {
         printf("Please use %i byte iv.\n", RC4PLUS_IV_SIZE);
-        return -1;
+        return NULL;
     }
-    //Copy the iv
-    memcpy(RC4PLUS_IV, iv, RC4PLUS_IV_SIZE);
 
-    //Init RC4PLUS_STATE
+    rc4struct *ret = (rc4struct *)malloc(sizeof(rc4struct));
+    if ( ret == NULL ) {
+        //Memory allocation error
+        return NULL;
+    }
+    //Setting the rc4+'s enc-dec function
+    ret->enc_dec_func = rc4plus_encdec;
+
+    //Init the state
     for ( size_t i = 256; i-- ; )
-        RC4PLUS_STATE[i] = i;
+        ret->state[i] = i;
     unsigned char j = 0;
     unsigned char temp;
     //Key loading
     for ( size_t i = 0 ; i < 256 ; ++i ) {
-        j += RC4PLUS_STATE[i] + key[i % key_length];
+        j += ret->state[i] + key[i % key_length];
         //swap part
-        temp = RC4PLUS_STATE[i];
-        RC4PLUS_STATE[i] = RC4PLUS_STATE[j];
-        RC4PLUS_STATE[j] = temp;
+        temp = ret->state[i];
+        ret->state[i] = ret->state[j];
+        ret->state[j] = temp;
     }
     //IV loading
     for ( size_t i = 128 ; i-- ; ) {
-        j += RC4PLUS_STATE[i];
-        j ^= key[i % key_length] + get_iv_char(i);
-        temp = RC4PLUS_STATE[i];
-        RC4PLUS_STATE[i] = RC4PLUS_STATE[j];
-        RC4PLUS_STATE[j] = temp;
+        j += ret->state[i];
+        j ^= key[i % key_length] + get_iv_char(iv, i);
+        temp = ret->state[i];
+        ret->state[i] = ret->state[j];
+        ret->state[j] = temp;
     }
     for ( size_t i = 128 ; i < 256 ; ++i ) {
-        j += RC4PLUS_STATE[i];
-        j ^= key[i % key_length] + get_iv_char(i);
-        temp = RC4PLUS_STATE[i];
-        RC4PLUS_STATE[i] = RC4PLUS_STATE[j];
-        RC4PLUS_STATE[j] = temp;
+        j += ret->state[i];
+        j ^= key[i % key_length] + get_iv_char(iv, i);
+        temp = ret->state[i];
+        ret->state[i] = ret->state[j];
+        ret->state[j] = temp;
     }
     //Zig-Zag Scrambling
     size_t i = 0;
@@ -76,24 +90,24 @@ int rc4plus_set_key(const char *const key, const char *const iv)
         } else {
             i = 128 - ((y+1)/2);
         }
-        j += RC4PLUS_STATE[i] + key[i % key_length];
-        temp = RC4PLUS_STATE[i];
-        RC4PLUS_STATE[i] = RC4PLUS_STATE[j];
-        RC4PLUS_STATE[j] = temp;
+        j += ret->state[i] + key[i % key_length];
+        temp = ret->state[i];
+        ret->state[i] = ret->state[j];
+        ret->state[j] = temp;
     }
-    return 0;
+    return ret;
 }
 
-int rc4plus(char *data, size_t size)
+int rc4plus_encdec(char *data, size_t size, off_t offset, const unsigned char *const state)
 {
-    if ( data == NULL ) {
+    if ( data == NULL || state == NULL ) {
         //NULL ptr error
         return -1;
     }
 
-    //Getting state matrix
-    unsigned char state[256]; 
-    memcpy(state, RC4PLUS_STATE, 256);
+    //Copying state matrix
+    unsigned char tmp_state[256]; 
+    memcpy(tmp_state, state, 256);
 
     //Part of random generation algorithm
     //Algorithm encrypts the given size of the data
@@ -101,18 +115,30 @@ int rc4plus(char *data, size_t size)
     unsigned char j = 0;
     unsigned char t1, t2, t3;
     unsigned char temp;
+    //offset part
+    for ( size_t x = 0 ; x < offset ; ++x ) {
+        i += 1;
+        j += tmp_state[i];
+        temp = tmp_state[i];
+        tmp_state[i] = tmp_state[j];
+        tmp_state[j] = temp;
+        t1 = tmp_state[i] + tmp_state[j];
+        t2 = (tmp_state[((i >> 3) ^ (j << 5)) % 256] + tmp_state[((i << 5) ^ ( j >> 3)) % 256]);
+        t2 ^= 0xAA;
+        t3 = j + tmp_state[j];
+    }
+    //enc part
     for ( size_t x = 0 ; x < size ; ++x ) {
         i += 1;
-        j += state[i];
-        temp = state[i];
-        state[i] = state[j];
-        state[j] = temp;
-        t1 = state[i] + state[j];
-        t2 = (state[((i >> 3) ^ (j << 5)) % 256] + state[((i << 5) ^ ( j >> 3)) % 256]);
+        j += tmp_state[i];
+        temp = tmp_state[i];
+        tmp_state[i] = tmp_state[j];
+        tmp_state[j] = temp;
+        t1 = tmp_state[i] + tmp_state[j];
+        t2 = (tmp_state[((i >> 3) ^ (j << 5)) % 256] + tmp_state[((i << 5) ^ ( j >> 3)) % 256]);
         t2 ^= 0xAA;
-        t3 = j + state[j];
-        data[x] ^= (state[t1] + state[t2]) ^ state[t3];
+        t3 = j + tmp_state[j];
+        data[x] ^= (tmp_state[t1] + tmp_state[t2]) ^ tmp_state[t3];
     }
-
     return 0;
 }

--- a/src/rc4plus.h
+++ b/src/rc4plus.h
@@ -1,15 +1,19 @@
 #ifndef RC4FS_RC4PLUS_H
 #define RC4FS_RC4PLUS_H
 
-#include <string.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #define RC4PLUS_IV_SIZE 16
 
-extern unsigned char RC4PLUS_STATE[256];
-extern unsigned char RC4PLUS_IV[RC4PLUS_IV_SIZE];
+typedef struct _rc4struct {
+    unsigned char state[256];
+    int (*enc_dec_func)(char *, size_t, off_t, const unsigned char *const);
+} rc4struct;
 
-int rc4plus_set_key(const char *const, const char *const);
-int rc4plus(char *, size_t);
+rc4struct *rc4plus_init(const char *const, const char *const);
+int rc4plus_destroy(rc4struct *);
+int rc4plus_encdec(char *, size_t, off_t, const unsigned char *const);
 
 #endif


### PR DESCRIPTION
Global state matrix that is held in global was removed. Instead new struct was implemented, it holds state and pointer to enc-dec function. Also offset feature was added to enc-dec function.